### PR TITLE
Fix duplicate setError call

### DIFF
--- a/components/MusicPlayer.tsx
+++ b/components/MusicPlayer.tsx
@@ -201,7 +201,6 @@ export default function MusicPlayer({ defaultTrack }: MusicPlayerProps) {
           callback: (err: any) => {
             if (err) {
               console.error(new Date().toISOString(), "Load error:", err)
-              setError('Error loading track. The track may have been removed or  "Load error:', err)
               setError("Error loading track. The track may have been removed or is unavailable.")
               setIsLoading(false)
 


### PR DESCRIPTION
## Summary
- remove malformed `setError` call in `MusicPlayer`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e05c8088832d926784cb99a4956d