### PR TITLE
Fix useToast listener effect

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,10 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // We intentionally run this effect only on mount/unmount
+    // to avoid adding duplicate listeners when the state updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listener registration in `useToast`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b49260c0832db6ac0cfe446632af