### PR TITLE
Add SoundCloud environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SOUNDCLOUD_CLIENT_ID=your_client_id_here

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -60,3 +60,21 @@ Follow these steps to set up the project locally:
    ```bash
    npm run dev
    ```
+
+## Environment Variables
+
+Set the following variable in a `.env.local` file:
+
+```
+SOUNDCLOUD_CLIENT_ID=your_client_id_here
+```
+
+You can copy `.env.example` and add your actual ID.
+
+### Obtaining a SoundCloud Client ID
+1. Sign in to SoundCloud and open the Developer Tools in your browser.
+2. Play any track and inspect the network requests.
+3. Locate requests to `api.soundcloud.com` that include a `client_id` parameter.
+4. Copy the `client_id` value and paste it into `.env.local`.
+
+


### PR DESCRIPTION
## Summary
- document required environment variables
- add instructions for getting a SoundCloud client ID
- track an example env file
- allow committing .env.example via .gitignore tweak

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ecf6eae8832da5a86b981178fc79